### PR TITLE
Add portfolio site skeleton with styles and placeholder portrait

### DIFF
--- a/assets/vinayaka-profile.svg
+++ b/assets/vinayaka-profile.svg
@@ -1,0 +1,22 @@
+<svg width="900" height="1100" viewBox="0 0 900 1100" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#132958"/>
+      <stop offset="100%" stop-color="#0A1737"/>
+    </linearGradient>
+    <linearGradient id="shirt" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#253F7F"/>
+      <stop offset="100%" stop-color="#1A2B56"/>
+    </linearGradient>
+  </defs>
+  <rect width="900" height="1100" fill="url(#bg)"/>
+  <circle cx="450" cy="340" r="145" fill="#E6C7AB"/>
+  <rect x="320" y="470" width="260" height="90" rx="38" fill="#E1BEA0"/>
+  <path d="M180 1100C220 820 320 680 450 680C580 680 680 820 720 1100H180Z" fill="url(#shirt)"/>
+  <rect x="280" y="690" width="340" height="380" rx="60" fill="#203867" opacity="0.65"/>
+  <circle cx="400" cy="320" r="12" fill="#2D2A2A"/>
+  <circle cx="500" cy="320" r="12" fill="#2D2A2A"/>
+  <path d="M400 390C430 420 470 420 500 390" stroke="#9A6E53" stroke-width="10" stroke-linecap="round"/>
+  <path d="M300 250C330 180 390 145 450 145C520 145 585 190 600 270" stroke="#171E2E" stroke-width="58" stroke-linecap="round"/>
+  <text x="450" y="1030" text-anchor="middle" fill="#DDE9FF" font-family="Inter, Arial, sans-serif" font-size="34" opacity="0.82">Professional Portrait Placeholder</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vinayaka Karnam | Business Analyst Portfolio</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="ambient ambient-a"></div>
+  <div class="ambient ambient-b"></div>
+
+  <div class="site-shell">
+    <header class="header glass">
+      <div class="brand-block">
+        <p class="brand-name">VINAYAKA KARNAM</p>
+        <p class="brand-subtitle">Business Analyst | SaaS &amp; Enterprise Systems</p>
+      </div>
+
+      <nav class="nav-links" aria-label="Primary">
+        <a href="#home">Home</a>
+        <a href="#about">About</a>
+        <a href="#experience">Experience</a>
+        <a href="#skills">Skills</a>
+        <a href="#projects">Projects</a>
+        <a href="#contact">Contact</a>
+      </nav>
+
+      <a href="#" class="btn btn-resume" aria-label="Download Resume">
+        <span aria-hidden="true">⬇</span>
+        <span>Download Resume</span>
+      </a>
+    </header>
+
+    <main>
+      <section id="home" class="hero glass section">
+        <div class="hero-copy">
+          <p class="eyebrow">Hello, I'm Vinayaka Karnam</p>
+          <h1>Business Analyst</h1>
+          <p class="hero-tagline">Transforming Business Needs into Scalable Solutions</p>
+
+          <ul class="feature-list">
+            <li>Enterprise SaaS</li>
+            <li>Requirements Gathering</li>
+            <li>SSO &amp; Integrations</li>
+            <li>Data Analysis</li>
+            <li>Process Optimization</li>
+          </ul>
+
+          <div class="cta-row">
+            <a href="#experience" class="btn btn-primary">View Experience</a>
+            <a href="#contact" class="btn btn-secondary">Contact Me</a>
+          </div>
+        </div>
+
+        <aside class="hero-media">
+          <div class="portrait-card">
+            <img src="assets/vinayaka-profile.svg" alt="Professional portrait of Vinayaka Karnam" />
+            <div class="tech-overlay" aria-hidden="true"></div>
+            <div class="chip chip-lock">🔒 SSO Security</div>
+            <div class="chip chip-analytics">📈 Analytics + Insights</div>
+          </div>
+        </aside>
+      </section>
+
+      <section id="about" class="section about glass">
+        <div class="section-head">
+          <p class="kicker">Profile</p>
+          <h2>About</h2>
+        </div>
+        <p>
+          I specialize in translating business requirements into robust functional solutions across enterprise SaaS ecosystems.
+          From stakeholder workshops and documentation to implementation validation, I ensure every initiative is aligned with
+          business outcomes, technical feasibility, and scalable delivery.
+        </p>
+        <div class="icon-tags">
+          <span>📄 BRD / FRD / SRS</span>
+          <span>🔐 SAML / SSO</span>
+          <span>📊 GA4 &amp; GTM</span>
+          <span>🧮 SQL</span>
+        </div>
+      </section>
+
+      <section id="skills" class="section skills glass">
+        <div class="section-head">
+          <p class="kicker">Capabilities</p>
+          <h2>Key Skills</h2>
+        </div>
+        <div class="skills-grid">
+          <article>Business Analysis</article>
+          <article>BRD / FRD / SRS</article>
+          <article>SAML &amp; SSO</article>
+          <article>Google Analytics</article>
+          <article>SQL</article>
+          <article>Stakeholder Management</article>
+          <article>Process Improvement</article>
+          <article>UAT &amp; Testing</article>
+        </div>
+      </section>
+
+      <section id="experience" class="section experience glass">
+        <div class="section-head">
+          <p class="kicker">Career</p>
+          <h2>Professional Experience</h2>
+        </div>
+
+        <div class="timeline">
+          <article class="exp-item">
+            <div class="timeline-dot"></div>
+            <div class="exp-card">
+              <div class="company-mark">PS</div>
+              <div>
+                <h3>PowerSchool – Business Systems Analyst</h3>
+                <p class="meta">Jan 2024 – Present · Bengaluru</p>
+                <p>Leading requirements lifecycle, enterprise SaaS enhancements, and secure SSO integration initiatives for business-critical systems.</p>
+              </div>
+            </div>
+          </article>
+
+          <article class="exp-item">
+            <div class="timeline-dot"></div>
+            <div class="exp-card">
+              <div class="company-mark">EPD</div>
+              <div>
+                <h3>EPD Solutions – Business/Technical Analyst</h3>
+                <p class="meta">Enterprise Delivery Role</p>
+                <p>Delivered process optimization recommendations, analytics-backed reporting improvements, and cross-functional solution blueprints.</p>
+              </div>
+            </div>
+          </article>
+
+          <article class="exp-item">
+            <div class="timeline-dot"></div>
+            <div class="exp-card">
+              <div class="company-mark">AT</div>
+              <div>
+                <h3>Archik Technologies – Associate Business Analyst</h3>
+                <p class="meta">Foundational BA Role</p>
+                <p>Contributed to BRD/FRD documentation, UAT execution, and stakeholder coordination for enterprise-focused implementations.</p>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section id="projects" class="section projects glass">
+        <div class="section-head">
+          <p class="kicker">Work Highlights</p>
+          <h2>Projects</h2>
+        </div>
+        <p class="muted">Enterprise SaaS process transformation, SSO onboarding programs, and analytics modernization projects can be featured here.</p>
+      </section>
+
+      <section id="contact" class="section contact glass">
+        <div class="section-head">
+          <p class="kicker">Get in Touch</p>
+          <h2>Contact</h2>
+        </div>
+        <p class="muted">Open to global Business Analyst opportunities across SaaS product companies and enterprise consulting teams.</p>
+      </section>
+    </main>
+  </div>
+</body>
+</html>

--- a/portfolio.css
+++ b/portfolio.css
@@ -1,0 +1,407 @@
+:root {
+  --bg: #070f23;
+  --bg-deep: #050b1a;
+  --surface: rgba(12, 24, 55, 0.74);
+  --surface-strong: rgba(17, 34, 72, 0.88);
+  --text: #f2f6ff;
+  --muted: #b3c3e5;
+  --line: rgba(164, 190, 245, 0.28);
+  --primary: #5b8cff;
+  --primary-2: #7db6ff;
+  --ring: 0 0 0 1px rgba(120, 162, 255, 0.28);
+  --shadow-lg: 0 20px 48px rgba(2, 8, 27, 0.5);
+  --shadow-md: 0 12px 28px rgba(5, 12, 35, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  font-family: "Inter", sans-serif;
+  color: var(--text);
+  background: radial-gradient(circle at 16% 10%, #162f66 0%, var(--bg) 38%),
+    linear-gradient(180deg, #081127 0%, var(--bg-deep) 100%);
+  scroll-behavior: smooth;
+}
+
+body {
+  min-height: 100vh;
+  padding: clamp(1rem, 2vw, 2rem);
+  overflow-x: hidden;
+}
+
+.ambient {
+  position: fixed;
+  border-radius: 999px;
+  filter: blur(70px);
+  z-index: -1;
+}
+
+.ambient-a {
+  width: 360px;
+  height: 360px;
+  top: -90px;
+  left: -80px;
+  background: rgba(85, 134, 255, 0.24);
+}
+
+.ambient-b {
+  width: 320px;
+  height: 320px;
+  bottom: 12%;
+  right: -90px;
+  background: rgba(65, 194, 255, 0.16);
+}
+
+.site-shell {
+  width: min(1220px, 100%);
+  margin: 0 auto;
+}
+
+.glass {
+  border: 1px solid var(--line);
+  background: linear-gradient(145deg, var(--surface-strong), var(--surface));
+  box-shadow: var(--shadow-lg);
+  backdrop-filter: blur(6px);
+}
+
+.header {
+  border-radius: 20px;
+  padding: 1rem 1.2rem;
+  margin-bottom: 1rem;
+  display: grid;
+  grid-template-columns: 1.35fr auto auto;
+  align-items: center;
+  gap: 1rem;
+}
+
+.brand-name {
+  margin: 0;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+}
+
+.brand-subtitle {
+  margin: 0.3rem 0 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.nav-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.8rem;
+}
+
+.nav-links a {
+  color: var(--text);
+  text-decoration: none;
+  font-size: 0.92rem;
+  opacity: 0.9;
+  transition: color 0.25s ease, opacity 0.25s ease;
+}
+
+.nav-links a:hover {
+  color: var(--primary-2);
+  opacity: 1;
+}
+
+.section {
+  border-radius: 22px;
+  padding: clamp(1.2rem, 2.2vw, 2rem);
+  margin-bottom: 1rem;
+  animation: rise-in 0.55s ease both;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: 1.06fr 0.94fr;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--primary-2);
+  font-weight: 600;
+}
+
+h1 {
+  margin: 0.35rem 0;
+  font-size: clamp(2.2rem, 5.2vw, 4rem);
+  letter-spacing: -0.02em;
+}
+
+.hero-tagline {
+  margin-top: 0;
+  color: var(--muted);
+  font-size: 1.08rem;
+}
+
+.feature-list {
+  list-style: none;
+  padding: 0;
+  margin: 1.1rem 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(150px, 1fr));
+  gap: 0.6rem;
+}
+
+.feature-list li {
+  border: 1px solid rgba(163, 194, 255, 0.3);
+  border-radius: 12px;
+  padding: 0.62rem 0.75rem;
+  background: rgba(87, 126, 222, 0.13);
+  color: #e6efff;
+  font-size: 0.93rem;
+}
+
+.cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+.btn {
+  border-radius: 999px;
+  padding: 0.75rem 1.2rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  text-decoration: none;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+}
+
+.btn-resume,
+.btn-primary {
+  color: #fff;
+  background: linear-gradient(135deg, var(--primary), var(--primary-2));
+  box-shadow: 0 12px 28px rgba(77, 131, 255, 0.38);
+}
+
+.btn-secondary {
+  color: var(--text);
+  border: 1px solid rgba(176, 202, 255, 0.5);
+  background: rgba(146, 181, 255, 0.1);
+}
+
+.portrait-card {
+  position: relative;
+  min-height: 430px;
+  border-radius: 20px;
+  overflow: hidden;
+  box-shadow: var(--shadow-md);
+  border: 1px solid rgba(194, 214, 255, 0.35);
+}
+
+.portrait-card img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.tech-overlay {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(125, 168, 255, 0.25) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(125, 168, 255, 0.25) 1px, transparent 1px),
+    radial-gradient(circle at 18% 80%, rgba(103, 154, 255, 0.38), transparent 44%);
+  background-size: 30px 30px, 30px 30px, 100% 100%;
+  mix-blend-mode: screen;
+}
+
+.chip {
+  position: absolute;
+  border-radius: 999px;
+  padding: 0.45rem 0.75rem;
+  font-size: 0.82rem;
+  border: 1px solid rgba(205, 223, 255, 0.45);
+  background: rgba(6, 14, 34, 0.84);
+  box-shadow: var(--ring);
+}
+
+.chip-lock {
+  top: 1rem;
+  left: 1rem;
+}
+
+.chip-analytics {
+  right: 1rem;
+  bottom: 1rem;
+}
+
+.section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.kicker {
+  margin: 0;
+  color: var(--primary-2);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+}
+
+h2 {
+  margin: 0 0 1rem;
+  font-size: clamp(1.35rem, 2vw, 1.8rem);
+}
+
+.about p,
+.muted,
+.exp-card p,
+.meta {
+  color: var(--muted);
+}
+
+.icon-tags {
+  margin-top: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.icon-tags span,
+.skills-grid article {
+  border-radius: 999px;
+  border: 1px solid rgba(180, 207, 255, 0.34);
+  background: rgba(101, 139, 225, 0.14);
+  padding: 0.52rem 0.86rem;
+  font-size: 0.9rem;
+}
+
+.skills-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(140px, 1fr));
+  gap: 0.6rem;
+}
+
+.timeline {
+  position: relative;
+  margin-top: 0.4rem;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.timeline::before {
+  content: "";
+  position: absolute;
+  left: 12px;
+  top: 0.2rem;
+  bottom: 0.2rem;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(124, 169, 255, 0.7), rgba(124, 169, 255, 0.1));
+}
+
+.exp-item {
+  display: grid;
+  grid-template-columns: 24px 1fr;
+  gap: 0.8rem;
+  align-items: start;
+}
+
+.timeline-dot {
+  width: 12px;
+  height: 12px;
+  margin-top: 1rem;
+  border-radius: 999px;
+  background: linear-gradient(145deg, #8ec0ff, #4f8dff);
+  box-shadow: 0 0 0 5px rgba(89, 142, 255, 0.18);
+}
+
+.exp-card {
+  border: 1px solid rgba(169, 195, 255, 0.28);
+  background: rgba(14, 27, 58, 0.76);
+  border-radius: 16px;
+  padding: 1rem;
+  display: grid;
+  grid-template-columns: 56px 1fr;
+  gap: 0.95rem;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.exp-card:hover {
+  border-color: rgba(133, 182, 255, 0.58);
+  transform: translateY(-2px);
+}
+
+.company-mark {
+  width: 50px;
+  height: 50px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(140deg, #3768cb, #22376a);
+  color: #eaf2ff;
+  font-weight: 700;
+  box-shadow: inset 0 1px 2px rgba(255, 255, 255, 0.23);
+}
+
+h3 {
+  margin: 0;
+  font-size: 1.04rem;
+}
+
+.meta {
+  margin: 0.3rem 0 0.45rem;
+  font-size: 0.88rem;
+}
+
+@keyframes rise-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 1080px) {
+  .header {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .btn-resume {
+    justify-self: center;
+  }
+
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .skills-grid {
+    grid-template-columns: repeat(2, minmax(140px, 1fr));
+  }
+}
+
+@media (max-width: 620px) {
+  .feature-list {
+    grid-template-columns: 1fr;
+  }
+
+  .skills-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .exp-card {
+    grid-template-columns: 1fr;
+  }
+}

--- a/portfolio.html
+++ b/portfolio.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vinayaka Karnam | Business Analyst Portfolio</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="portfolio.css" />
+</head>
+<body>
+  <div class="ambient ambient-a"></div>
+  <div class="ambient ambient-b"></div>
+
+  <div class="site-shell">
+    <header class="header glass">
+      <div class="brand-block">
+        <p class="brand-name">VINAYAKA KARNAM</p>
+        <p class="brand-subtitle">Business Analyst | SaaS &amp; Enterprise Systems</p>
+      </div>
+
+      <nav class="nav-links" aria-label="Primary">
+        <a href="#home">Home</a>
+        <a href="#about">About</a>
+        <a href="#experience">Experience</a>
+        <a href="#skills">Skills</a>
+        <a href="#projects">Projects</a>
+        <a href="#contact">Contact</a>
+      </nav>
+
+      <a href="#" class="btn btn-resume" aria-label="Download Resume">
+        <span aria-hidden="true">⬇</span>
+        <span>Download Resume</span>
+      </a>
+    </header>
+
+    <main>
+      <section id="home" class="hero glass section">
+        <div class="hero-copy">
+          <p class="eyebrow">Hello, I'm Vinayaka Karnam</p>
+          <h1>Business Analyst</h1>
+          <p class="hero-tagline">Transforming Business Needs into Scalable Solutions</p>
+
+          <ul class="feature-list">
+            <li>Enterprise SaaS</li>
+            <li>Requirements Gathering</li>
+            <li>SSO &amp; Integrations</li>
+            <li>Data Analysis</li>
+            <li>Process Optimization</li>
+          </ul>
+
+          <div class="cta-row">
+            <a href="#experience" class="btn btn-primary">View Experience</a>
+            <a href="#contact" class="btn btn-secondary">Contact Me</a>
+          </div>
+        </div>
+
+        <aside class="hero-media">
+          <div class="portrait-card">
+            <img src="https://images.unsplash.com/photo-1560250097-0b93528c311a?auto=format&fit=crop&w=1200&q=80" alt="Professional portrait of Vinayaka Karnam" />
+            <div class="tech-overlay" aria-hidden="true"></div>
+            <div class="chip chip-lock">🔒 SSO Security</div>
+            <div class="chip chip-analytics">📈 Analytics + Insights</div>
+          </div>
+        </aside>
+      </section>
+
+      <section id="about" class="section about glass">
+        <div class="section-head">
+          <p class="kicker">Profile</p>
+          <h2>About</h2>
+        </div>
+        <p>
+          I specialize in translating business requirements into robust functional solutions across enterprise SaaS ecosystems.
+          From stakeholder workshops and documentation to implementation validation, I ensure every initiative is aligned with
+          business outcomes, technical feasibility, and scalable delivery.
+        </p>
+        <div class="icon-tags">
+          <span>📄 BRD / FRD / SRS</span>
+          <span>🔐 SAML / SSO</span>
+          <span>📊 GA4 &amp; GTM</span>
+          <span>🧮 SQL</span>
+        </div>
+      </section>
+
+      <section id="skills" class="section skills glass">
+        <div class="section-head">
+          <p class="kicker">Capabilities</p>
+          <h2>Key Skills</h2>
+        </div>
+        <div class="skills-grid">
+          <article>Business Analysis</article>
+          <article>BRD / FRD / SRS</article>
+          <article>SAML &amp; SSO</article>
+          <article>Google Analytics</article>
+          <article>SQL</article>
+          <article>Stakeholder Management</article>
+          <article>Process Improvement</article>
+          <article>UAT &amp; Testing</article>
+        </div>
+      </section>
+
+      <section id="experience" class="section experience glass">
+        <div class="section-head">
+          <p class="kicker">Career</p>
+          <h2>Professional Experience</h2>
+        </div>
+
+        <div class="timeline">
+          <article class="exp-item">
+            <div class="timeline-dot"></div>
+            <div class="exp-card">
+              <div class="company-mark">PS</div>
+              <div>
+                <h3>PowerSchool – Business Systems Analyst</h3>
+                <p class="meta">Jan 2024 – Present · Bengaluru</p>
+                <p>Leading requirements lifecycle, enterprise SaaS enhancements, and secure SSO integration initiatives for business-critical systems.</p>
+              </div>
+            </div>
+          </article>
+
+          <article class="exp-item">
+            <div class="timeline-dot"></div>
+            <div class="exp-card">
+              <div class="company-mark">EPD</div>
+              <div>
+                <h3>EPD Solutions – Business/Technical Analyst</h3>
+                <p class="meta">Enterprise Delivery Role</p>
+                <p>Delivered process optimization recommendations, analytics-backed reporting improvements, and cross-functional solution blueprints.</p>
+              </div>
+            </div>
+          </article>
+
+          <article class="exp-item">
+            <div class="timeline-dot"></div>
+            <div class="exp-card">
+              <div class="company-mark">AT</div>
+              <div>
+                <h3>Archik Technologies – Associate Business Analyst</h3>
+                <p class="meta">Foundational BA Role</p>
+                <p>Contributed to BRD/FRD documentation, UAT execution, and stakeholder coordination for enterprise-focused implementations.</p>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section id="projects" class="section projects glass">
+        <div class="section-head">
+          <p class="kicker">Work Highlights</p>
+          <h2>Projects</h2>
+        </div>
+        <p class="muted">Enterprise SaaS process transformation, SSO onboarding programs, and analytics modernization projects can be featured here.</p>
+      </section>
+
+      <section id="contact" class="section contact glass">
+        <div class="section-head">
+          <p class="kicker">Get in Touch</p>
+          <h2>Contact</h2>
+        </div>
+        <p class="muted">Open to global Business Analyst opportunities across SaaS product companies and enterprise consulting teams.</p>
+      </section>
+    </main>
+  </div>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,407 @@
+:root {
+  --bg: #070f23;
+  --bg-deep: #050b1a;
+  --surface: rgba(12, 24, 55, 0.74);
+  --surface-strong: rgba(17, 34, 72, 0.88);
+  --text: #f2f6ff;
+  --muted: #b3c3e5;
+  --line: rgba(164, 190, 245, 0.28);
+  --primary: #5b8cff;
+  --primary-2: #7db6ff;
+  --ring: 0 0 0 1px rgba(120, 162, 255, 0.28);
+  --shadow-lg: 0 20px 48px rgba(2, 8, 27, 0.5);
+  --shadow-md: 0 12px 28px rgba(5, 12, 35, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", Roboto, Arial, sans-serif;
+  color: var(--text);
+  background: radial-gradient(circle at 16% 10%, #162f66 0%, var(--bg) 38%),
+    linear-gradient(180deg, #081127 0%, var(--bg-deep) 100%);
+  scroll-behavior: smooth;
+}
+
+body {
+  min-height: 100vh;
+  padding: clamp(1rem, 2vw, 2rem);
+  overflow-x: hidden;
+}
+
+.ambient {
+  position: fixed;
+  border-radius: 999px;
+  filter: blur(70px);
+  z-index: -1;
+}
+
+.ambient-a {
+  width: 360px;
+  height: 360px;
+  top: -90px;
+  left: -80px;
+  background: rgba(85, 134, 255, 0.24);
+}
+
+.ambient-b {
+  width: 320px;
+  height: 320px;
+  bottom: 12%;
+  right: -90px;
+  background: rgba(65, 194, 255, 0.16);
+}
+
+.site-shell {
+  width: min(1220px, 100%);
+  margin: 0 auto;
+}
+
+.glass {
+  border: 1px solid var(--line);
+  background: linear-gradient(145deg, var(--surface-strong), var(--surface));
+  box-shadow: var(--shadow-lg);
+  backdrop-filter: blur(6px);
+}
+
+.header {
+  border-radius: 20px;
+  padding: 1rem 1.2rem;
+  margin-bottom: 1rem;
+  display: grid;
+  grid-template-columns: 1.35fr auto auto;
+  align-items: center;
+  gap: 1rem;
+}
+
+.brand-name {
+  margin: 0;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+}
+
+.brand-subtitle {
+  margin: 0.3rem 0 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.nav-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.8rem;
+}
+
+.nav-links a {
+  color: var(--text);
+  text-decoration: none;
+  font-size: 0.92rem;
+  opacity: 0.9;
+  transition: color 0.25s ease, opacity 0.25s ease;
+}
+
+.nav-links a:hover {
+  color: var(--primary-2);
+  opacity: 1;
+}
+
+.section {
+  border-radius: 22px;
+  padding: clamp(1.2rem, 2.2vw, 2rem);
+  margin-bottom: 1rem;
+  animation: rise-in 0.55s ease both;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: 1.06fr 0.94fr;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--primary-2);
+  font-weight: 600;
+}
+
+h1 {
+  margin: 0.35rem 0;
+  font-size: clamp(2.2rem, 5.2vw, 4rem);
+  letter-spacing: -0.02em;
+}
+
+.hero-tagline {
+  margin-top: 0;
+  color: var(--muted);
+  font-size: 1.08rem;
+}
+
+.feature-list {
+  list-style: none;
+  padding: 0;
+  margin: 1.1rem 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(150px, 1fr));
+  gap: 0.6rem;
+}
+
+.feature-list li {
+  border: 1px solid rgba(163, 194, 255, 0.3);
+  border-radius: 12px;
+  padding: 0.62rem 0.75rem;
+  background: rgba(87, 126, 222, 0.13);
+  color: #e6efff;
+  font-size: 0.93rem;
+}
+
+.cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+.btn {
+  border-radius: 999px;
+  padding: 0.75rem 1.2rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  text-decoration: none;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+}
+
+.btn-resume,
+.btn-primary {
+  color: #fff;
+  background: linear-gradient(135deg, var(--primary), var(--primary-2));
+  box-shadow: 0 12px 28px rgba(77, 131, 255, 0.38);
+}
+
+.btn-secondary {
+  color: var(--text);
+  border: 1px solid rgba(176, 202, 255, 0.5);
+  background: rgba(146, 181, 255, 0.1);
+}
+
+.portrait-card {
+  position: relative;
+  min-height: 430px;
+  border-radius: 20px;
+  overflow: hidden;
+  box-shadow: var(--shadow-md);
+  border: 1px solid rgba(194, 214, 255, 0.35);
+}
+
+.portrait-card img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.tech-overlay {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(125, 168, 255, 0.25) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(125, 168, 255, 0.25) 1px, transparent 1px),
+    radial-gradient(circle at 18% 80%, rgba(103, 154, 255, 0.38), transparent 44%);
+  background-size: 30px 30px, 30px 30px, 100% 100%;
+  mix-blend-mode: screen;
+}
+
+.chip {
+  position: absolute;
+  border-radius: 999px;
+  padding: 0.45rem 0.75rem;
+  font-size: 0.82rem;
+  border: 1px solid rgba(205, 223, 255, 0.45);
+  background: rgba(6, 14, 34, 0.84);
+  box-shadow: var(--ring);
+}
+
+.chip-lock {
+  top: 1rem;
+  left: 1rem;
+}
+
+.chip-analytics {
+  right: 1rem;
+  bottom: 1rem;
+}
+
+.section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.kicker {
+  margin: 0;
+  color: var(--primary-2);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+}
+
+h2 {
+  margin: 0 0 1rem;
+  font-size: clamp(1.35rem, 2vw, 1.8rem);
+}
+
+.about p,
+.muted,
+.exp-card p,
+.meta {
+  color: var(--muted);
+}
+
+.icon-tags {
+  margin-top: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.icon-tags span,
+.skills-grid article {
+  border-radius: 999px;
+  border: 1px solid rgba(180, 207, 255, 0.34);
+  background: rgba(101, 139, 225, 0.14);
+  padding: 0.52rem 0.86rem;
+  font-size: 0.9rem;
+}
+
+.skills-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(140px, 1fr));
+  gap: 0.6rem;
+}
+
+.timeline {
+  position: relative;
+  margin-top: 0.4rem;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.timeline::before {
+  content: "";
+  position: absolute;
+  left: 12px;
+  top: 0.2rem;
+  bottom: 0.2rem;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(124, 169, 255, 0.7), rgba(124, 169, 255, 0.1));
+}
+
+.exp-item {
+  display: grid;
+  grid-template-columns: 24px 1fr;
+  gap: 0.8rem;
+  align-items: start;
+}
+
+.timeline-dot {
+  width: 12px;
+  height: 12px;
+  margin-top: 1rem;
+  border-radius: 999px;
+  background: linear-gradient(145deg, #8ec0ff, #4f8dff);
+  box-shadow: 0 0 0 5px rgba(89, 142, 255, 0.18);
+}
+
+.exp-card {
+  border: 1px solid rgba(169, 195, 255, 0.28);
+  background: rgba(14, 27, 58, 0.76);
+  border-radius: 16px;
+  padding: 1rem;
+  display: grid;
+  grid-template-columns: 56px 1fr;
+  gap: 0.95rem;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.exp-card:hover {
+  border-color: rgba(133, 182, 255, 0.58);
+  transform: translateY(-2px);
+}
+
+.company-mark {
+  width: 50px;
+  height: 50px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(140deg, #3768cb, #22376a);
+  color: #eaf2ff;
+  font-weight: 700;
+  box-shadow: inset 0 1px 2px rgba(255, 255, 255, 0.23);
+}
+
+h3 {
+  margin: 0;
+  font-size: 1.04rem;
+}
+
+.meta {
+  margin: 0.3rem 0 0.45rem;
+  font-size: 0.88rem;
+}
+
+@keyframes rise-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 1080px) {
+  .header {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .btn-resume {
+    justify-self: center;
+  }
+
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .skills-grid {
+    grid-template-columns: repeat(2, minmax(140px, 1fr));
+  }
+}
+
+@media (max-width: 620px) {
+  .feature-list {
+    grid-template-columns: 1fr;
+  }
+
+  .skills-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .exp-card {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight personal portfolio skeleton for Vinayaka Karnam with a hero/profile, experience, skills, projects, and contact sections.
- Include a reusable visual style and a placeholder portrait so the site can be previewed and iterated on quickly.

### Description
- Added `index.html` and `portfolio.html` as entry pages implementing the site structure and hero/profile sections including navigation, timeline, skills grid, and contact placeholders.
- Added responsive styling via `style.css` and `portfolio.css` implementing the glassy UI, ambient gradients, layout grid, and components such as `.portrait-card`, `.chip`, and `.exp-card`.
- Added a vector placeholder portrait asset at `assets/vinayaka-profile.svg` and wired it into `index.html` while `portfolio.html` uses an external placeholder image for preview.
- Included Google Fonts in `portfolio.html` and ensured responsive behavior with media queries for typical breakpoint widths.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaed470ebc8326b5dce7d6aacb5863)